### PR TITLE
fix: vite v6对旧插件的类型不适配（虽然不影响使用），并且配置primevue跟随页面主题

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -54,13 +54,13 @@ export default defineConfig({
       host: "localhost",
       port: 8080
     },
-    plugins: [  // @ts-ignore
+    plugins: [
       AutoSidebar({
         path: 'novels/',
         ignoreList: ['.outline.md', '_'],
         ignoreIndexItem: true,
         titleFromFile: true,
-      }),  // @ts-ignore
+      }),
       UnoCSS(),
     ],
     build: {

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -1,6 +1,6 @@
+import type { EnhanceAppContext } from 'vitepress'
 import DefaultTheme from 'vitepress/theme';
 import type { Theme } from "vitepress";
-import { App } from 'vue';
 import { createPinia } from "pinia";
 import piniaPluginPersistedstate from 'pinia-plugin-persistedstate'
 
@@ -17,15 +17,22 @@ import Cover from './components/Cover.vue';
 import PartHead from './components/PartHead.vue';
 import CornerBrackets from './components/CornerBrackets.vue';
 
-export default {
+export default <Theme> {
   ...DefaultTheme,
-  // @ts-ignore
-  enhanceApp({ app }: {app: App}) {
-    let pinia = createPinia()
+  enhanceApp({ app }: EnhanceAppContext) {
+    let pinia: any = createPinia()
     pinia.use(piniaPluginPersistedstate)
-    app.use(PrimeVue, { theme: { preset: Lara } })
-    app.use(ToastService)
+    app.use(PrimeVue as any, {
+      theme: {
+        preset: Lara,
+        options: {
+          darkModeSelector: ".dark"
+        }
+      }
+    })
+    app.use(ToastService as any)
     app.component('v-markdown', Vue3MarkdownIt)
+    // @ts-expect-error hack :)
     app.component('cover', Cover)
     app.component('part-head', PartHead)
     app.component('uv', UseVar)
@@ -33,5 +40,4 @@ export default {
     app.use(pinia)
   },
   Layout,
-  // @ts-ignore
 } satisfies Theme;

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "shiki": "^1.24.0",
     "taze": "^0.18.0",
     "unocss": "^0.64.1",
-    "vite": "^6.0.1"
+    "vite": "5.4.11"
   },
   "packageManager": "yarn@1.22.22"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,32 @@
+{
+    "compilerOptions": {
+        "target": "ESNext",
+        "jsx": "preserve",
+        "lib": [
+            "DOM",
+            "ESNext"
+        ],
+        "baseUrl": ".",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "paths": {
+            "~/*": [
+                "src/*"
+            ]
+        },
+        "resolveJsonModule": true,
+        "types": [
+            "vite/client",
+            "vitepress"
+        ],
+        "strict": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "ignoreDeprecations": "5.0"
+    },
+    "exclude": [
+        ".vitepress/dist",
+        "node_modules"
+    ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,7 +3344,7 @@ postcss@^8.4.43, postcss@^8.4.47:
     picocolors "^1.1.0"
     source-map-js "^1.2.1"
 
-postcss@^8.4.48, postcss@^8.4.49:
+postcss@^8.4.48:
   version "8.4.49"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.49.tgz#4ea479048ab059ab3ae61d082190fabfd994fe19"
   integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
@@ -3493,7 +3493,7 @@ rollup@^4.20.0:
     "@rollup/rollup-win32-x64-msvc" "4.24.0"
     fsevents "~2.3.2"
 
-rollup@^4.23.0, rollup@^4.27.4:
+rollup@^4.27.4:
   version "4.27.4"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.27.4.tgz#b23e4ef4fe4d0d87f5237dacf63f95a499503897"
   integrity sha512-RLKxqHEMjh/RGLsDxAEsaLO3mWgyoU6x9w6n1ikAzet4B3gI2/3yP6PWY2p9QzRTh6MfEIXB3MwsOY0Iv3vNrw==
@@ -3983,7 +3983,7 @@ vite-plugin-vitepress-auto-sidebar@^1.7.0:
     front-matter "^4.0.2"
     picocolors "^1.0.0"
 
-vite@^5.4.10:
+vite@^5.4.10, vite@^5.4.11:
   version "5.4.11"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.11.tgz#3b415cd4aed781a356c1de5a9ebafb837715f6e5"
   integrity sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==
@@ -3991,17 +3991,6 @@ vite@^5.4.10:
     esbuild "^0.21.3"
     postcss "^8.4.43"
     rollup "^4.20.0"
-  optionalDependencies:
-    fsevents "~2.3.3"
-
-vite@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/vite/-/vite-6.0.1.tgz#24c9caf24998f0598de37bed67e50ec5b9dfeaf0"
-  integrity sha512-Ldn6gorLGr4mCdFnmeAOLweJxZ34HjKnDm4HGo6P66IEqTxQb36VEdFJQENKxWjupNfoIjvRUnswjn1hpYEpjQ==
-  dependencies:
-    esbuild "^0.24.0"
-    postcss "^8.4.49"
-    rollup "^4.23.0"
   optionalDependencies:
     fsevents "~2.3.3"
 


### PR DESCRIPTION
- 修复primevue组件的主题切换
- 回退并锁定vite到v5版本（暂时